### PR TITLE
ci: fix test job permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to be able to delete branches
-      pull-requests: read # to be able to confirm that branches don't have associated PRs
+      contents: read # to be able to checkout
+      pull-requests: write # to be able to remove stale reviews
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The `test` job had only `pull-request: read` permission by mistake, and the action wasn't able to remove stale reviews because of it. Giving it `write` permissions should fix that.