### PR TITLE
ci: run Renovate as self-hosted with post-upgrade tasks

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,23 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get token
+        id: get-token
+        uses: tibdex/github-app-token@v1
+        with:
+          private_key: ${{ secrets.RENOVATE_PEM }}
+          app_id: ${{ secrets.RENOVATE_ID }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v39.0.5
+        with:
+          token: '${{ steps.get-token.outputs.token }}'

--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,10 @@
       "matchPackageNames": ["@types/node"],
       "allowedVersions": "/^20\\..*$/"
     }
-  ]
+  ],
+  "postUpgradeTasks": {
+    "commands": ["pnpm generate", "pnpm package"],
+    "fileFilters": ["**/*"],
+    "executionMode": "branch"
+  }
 }


### PR DESCRIPTION
The Renovate has to be run as self-hosted in order to use `postUpgradeTasks`. We need `postUpgradeTasks` to be able to generate new dist files automatically after the package upgrade.