### PR TITLE
ci: add allowedPostUpgradeCommands to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "minor": {
     "automerge": true
   },
@@ -13,6 +13,7 @@
       "allowedVersions": "/^20\\..*$/"
     }
   ],
+  "allowedPostUpgradeCommands": ["pnpm generate", "pnpm package"],
   "postUpgradeTasks": {
     "commands": ["pnpm generate", "pnpm package"],
     "fileFilters": ["**/*"],


### PR DESCRIPTION
Apparently `allowedPostUpgradeCommands` must define all commands used in `postUpgradeTasks` in order to make it work.
This PR adds `allowedPostUpgradeCommands` to the Renovate config.