### PR TITLE
ci: install all deps during Renovate upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,12 +11,14 @@
     {
       "matchPackageNames": ["@types/node"],
       "allowedVersions": "/^20\\..*$/"
+    },
+    {
+      "matchManagers": ["npm"],
+      "postUpgradeTasks": {
+        "commands": ["pnpm install", "pnpm generate", "pnpm package"],
+        "fileFilters": ["**/*"],
+        "executionMode": "branch"
+      }
     }
-  ],
-  "allowedPostUpgradeCommands": ["pnpm generate", "pnpm package"],
-  "postUpgradeTasks": {
-    "commands": ["pnpm generate", "pnpm package"],
-    "fileFilters": ["**/*"],
-    "executionMode": "branch"
-  }
+  ]
 }


### PR DESCRIPTION
Renovate only installs upgraded packages, but we need to install all packages in order to be able to run post-upgrade commands. So this PR adds `pnpm install` to the commands array