### PR TITLE
ci: filter files modified during post-upgrade tasks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
       "matchManagers": ["npm"],
       "postUpgradeTasks": {
         "commands": ["pnpm install", "pnpm generate", "pnpm package"],
-        "fileFilters": ["**/*"],
+        "fileFilters": ["src/**/*", "dist/**/*"],
         "executionMode": "branch"
       }
     }


### PR DESCRIPTION
Allow only `src/**` and `dist/**` files to be changed by Renovate post-upgrade tasks. This should prevent unwanted changes to files like `.npmrc` 