### PR TITLE
ci: enable Kodiak to be able to quickly merge Renovate

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[approve]
+auto_approve_usernames = ["balvajs-renovate"]
+
+[merge.automerge_dependencies]
+versions = ["minor", "patch"]
+usernames = ["balvajs-renovate"]


### PR DESCRIPTION
Enable Kodiak so the minor & patch Renovate upgrades are automatically approved & merged. 