### PR TITLE
ci: remove CODEOWNERS from auto changed files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 * @balvajs
+package.json
+pnpm-lock.yaml
+dist/
+__generated__


### PR DESCRIPTION
Remove CODEOWNERS from files that are automatically changed by Renovate, so the PRs are not blocked waiting for human approve and can be automerged.