### PR TITLE
ci: create GitHub releases automatically with @semantic-release/github

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,6 +7,7 @@
       "assets": ["dist/**", "action.yml", "package.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
+    "@semantic-release/github",
     "semantic-release-major-tag"
   ]
 }


### PR DESCRIPTION
`.releaserc` had no `@semantic-release/github`, so the release workflow only ever created tags — every GitHub release in this repo was made by hand with GitHub's auto-generated notes. Those notes silently drop the `BREAKING CHANGE:` footer, which is exactly the part consumers of an action need on a major: v4.0.0's break is a runner requirement (`node24`), and it appears nowhere in the auto-generated body.