### PR TITLE
chore: drop stale .vscode config and ignore local agent directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ Thumbs.db
 # Ignore built ts files
 __tests__/runner/*
 lib/**/*
+
+# Local agent tooling config
+.claude
+.superset

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "eslint.experimental.useFlatConfig": true
-}


### PR DESCRIPTION
`.vscode/settings.json` set `eslint.experimental.useFlatConfig` and `.vscode/extensions.json` recommended the eslint and prettier extensions — all three tools were removed in the oxc migration (#487), so the committed editor config now only points contributors at dead tooling. `.claude` and `.superset` are local agent scratch dirs that have no business in the tree.